### PR TITLE
Use withRouter HOC instead of context in Lesson 12

### DIFF
--- a/lessons/12-navigating/README.md
+++ b/lessons/12-navigating/README.md
@@ -70,31 +70,35 @@ common to use anything other than `browserHistory`, so this is
 acceptable practice. If you're concerned about it, you can make a module
 that exports the history you want to use across the app, or...
 
-You can also use the `router` that `Router` provides on "context".
-First, you ask for context in the component, and then you can use it:
+You can also access the router by wrapping your component with the 
+`withRouter` 
+[higher-order component](https://facebook.github.io/react/docs/higher-order-components.html),
+which will allow you to access the `Router` by passing it to your component in the `props`. 
+You can then access the router as `this.props.router`.
 
 ```js
-export default React.createClass({
+// modules/Repos.js
+import { withRouter } from 'react-router'
 
-  // ask for `router` from context
-  contextTypes: {
-    router: React.PropTypes.object
-  },
+var Repos = React.createClass({
 
   // ...
 
   handleSubmit(event) {
     // ...
-    this.context.router.push(path)
+    this.props.router.push(path)
   },
 
   // ..
 })
+
+var ReposWithRouter = withRouter(Repos);
+
+export default ReposWithRouter;
 ```
 
 This way you'll be sure to be pushing to whatever history gets passed to
-`Router`. It also makes testing a bit easier since you can more easily
-stub context than singletons.
+`Router`.
 
 ---
 


### PR DESCRIPTION
My short story:
I'm learning react-router, so I follow the tutorial and learn about `<Links>`. They work great. Now I want to make them work with Bootstrap, but I need to add the active class to the `<li>` instead of the `<a>`. I try to implement my own version of `<Link>` that adds the class in the correct place. It works on a page refresh but not while navigating, because my custom `<BootstrapLink>` gets the router from the context but doesn't subscribe to the `ContextSubscriber` mixin. I Google. I find `withRouter`. I think maybe it would be nice for this to be in the tutorial. 😄 

Hopefully this will save learners some time and googling.